### PR TITLE
Enable PCRE2 feature.

### DIFF
--- a/ripgrep.spec
+++ b/ripgrep.spec
@@ -1,6 +1,6 @@
 Name: ripgrep
 Version: 12.1.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A search tool that combines the usability of ag with the raw speed of grep
 License: MIT or Unlicense
 URL: https://github.com/BurntSushi/ripgrep
@@ -27,7 +27,7 @@ grep.
 
 
 %build
-cargo build --release
+cargo build --release --features 'pcre2'
 
 
 %install
@@ -53,6 +53,9 @@ cargo test
 
 
 %changelog
+* Fri Aug 26 2022 Jacob Egner <jacob@egner.computer> - 12.1.1-2
+- Enable PCRE2 feature
+
 * Thu Dec 31 2020 Konstantin Glukhov <konstantin@konstantin.computer> - 12.1.1-1
 - Latest upstream
 


### PR DESCRIPTION
As per [official building guidance](https://github.com/BurntSushi/ripgrep#building):  
>Finally, optional PCRE2 support can be built with ripgrep by enabling the pcre2 feature:  
>`$ cargo build --release --features 'pcre2'`  

Thanks so much for making it easy to install ripgrep on rpm systems.  I'm really looking forward to PCRE2 support so I can use your repo more rather than schlepping around an `rg` executable that has the feature.